### PR TITLE
Replace function str_replace() with urldecode()

### DIFF
--- a/classes/Resizer.php
+++ b/classes/Resizer.php
@@ -82,14 +82,16 @@ class Resizer
         // Check if the image is an absolute url to the same server, if so get the storage path of the image
         if (preg_match('/^(?:https?:\/\/)?' . $_SERVER['SERVER_NAME'] . '(?::\d+)?\/storage\/(.+)$/', $image, $m)) {
             // Convert spaces, not going to urldecode as it will mess with pluses
-            $image = storage_path(str_replace('%20', ' ', $m[1]));
+            //$image = storage_path(str_replace('%20', ' ', $m[1]));
+            $image = storage_path(urldecode($m[1]));
             $absolutePath = true;
         }
 
         // Check if the image is an absolute url to the same server, if so get the storage path of the image
         if (preg_match('/^(?:https?:\/\/)?' . $_SERVER['SERVER_NAME'] . '(?::\d+)?\/theme\/(.+)$/', $image, $m)) {
             // Convert spaces, not going to urldecode as it will mess with pluses
-            $image = base_path('theme/' . str_replace('%20', ' ', $m[1]));
+            //$image = base_path('theme/' . str_replace('%20', ' ', $m[1]));
+            $image = base_path('theme/' . urldecode($m[1]));
             $absolutePath = true;
         }
 

--- a/classes/Resizer.php
+++ b/classes/Resizer.php
@@ -82,7 +82,6 @@ class Resizer
         // Check if the image is an absolute url to the same server, if so get the storage path of the image
         if (preg_match('/^(?:https?:\/\/)?' . $_SERVER['SERVER_NAME'] . '(?::\d+)?\/storage\/(.+)$/', $image, $m)) {
             // Convert spaces, not going to urldecode as it will mess with pluses
-            //$image = storage_path(str_replace('%20', ' ', $m[1]));
             $image = storage_path(urldecode($m[1]));
             $absolutePath = true;
         }
@@ -90,7 +89,6 @@ class Resizer
         // Check if the image is an absolute url to the same server, if so get the storage path of the image
         if (preg_match('/^(?:https?:\/\/)?' . $_SERVER['SERVER_NAME'] . '(?::\d+)?\/theme\/(.+)$/', $image, $m)) {
             // Convert spaces, not going to urldecode as it will mess with pluses
-            //$image = base_path('theme/' . str_replace('%20', ' ', $m[1]));
             $image = base_path('theme/' . urldecode($m[1]));
             $absolutePath = true;
         }

--- a/classes/Resizer.php
+++ b/classes/Resizer.php
@@ -87,9 +87,9 @@ class Resizer
         }
 
         // Check if the image is an absolute url to the same server, if so get the storage path of the image
-        if (preg_match('/^(?:https?:\/\/)?' . $_SERVER['SERVER_NAME'] . '(?::\d+)?\/theme\/(.+)$/', $image, $m)) {
+        if (preg_match('/^(?:https?:\/\/)?' . $_SERVER['SERVER_NAME'] . '(?::\d+)?\/themes\/(.+)$/', $image, $m)) {
             // Convert spaces, not going to urldecode as it will mess with pluses
-            $image = base_path('theme/' . urldecode($m[1]));
+            $image = base_path('themes/' . urldecode($m[1]));
             $absolutePath = true;
         }
 


### PR DESCRIPTION
If image name contains non-Latin characters (for example Cyrillic) filter function can't locate the image file.