### PR TITLE
Add permalinks for images

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -5,6 +5,8 @@ namespace ABWebDevelopers\ImageResize;
 use ABWebDevelopers\ImageResize\Classes\Resizer;
 use ABWebDevelopers\ImageResize\Commands\ImageResizeClear;
 use ABWebDevelopers\ImageResize\Commands\ImageResizeGc;
+use ABWebDevelopers\ImageResize\Commands\ImageResizeResetPermalinks;
+use ABWebDevelopers\ImageResize\Models\ImagePermalink;
 use ABWebDevelopers\ImageResize\Models\Settings;
 use ABWebDevelopers\ImageResize\ReportWidgets\ImageResizeClearWidget;
 use App;
@@ -39,6 +41,24 @@ class Plugin extends PluginBase
     {
         return [
             'filters' => [
+                'resizePermalink' => function ($image, $identifier, $width, $height = null, $options = []) {
+                    $resizer = new Resizer((string) $image);
+
+                    $width = ($width !== null) ? (int) $width : null;
+                    $height = ($height !== null) ? (int) $height : null;
+                    $options = ($options instanceof Arrayable) ? $options->toArray() : (array) $options;
+
+                    return $resizer->resizePermalink($identifier, $width, $height, $options)->permalink_url;
+                },
+                'modifyPermalink' => function ($identifier, $image, $options = []) {
+                    $resizer = new Resizer((string) $image);
+
+                    $width = null;
+                    $height = null;
+                    $options = ($options instanceof Arrayable) ? $options->toArray() : (array) $options;
+
+                    return $resizer->resizePermalink($identifier, $width, $height, $options)->permalink_url;
+                },
                 'resize' => function ($image, $width, $height = null, $options = []) {
                     $resizer = new Resizer((string) $image);
 
@@ -146,6 +166,7 @@ class Plugin extends PluginBase
     {
         $this->registerConsoleCommand('imageresize:gc', ImageResizeGc::class);
         $this->registerConsoleCommand('imageresize:clear', ImageResizeClear::class);
+        $this->registerConsoleCommand('imageresize:reset-permalink', ImageResizeResetPermalinks::class);
     }
 
     /**
@@ -172,7 +193,7 @@ class Plugin extends PluginBase
 
     /**
      * Run the callback only if/when the database exists (and system_settings table exists).
-     * 
+     *
      * @param \Closure $callback
      * @return mixed
      */

--- a/Plugin.php
+++ b/Plugin.php
@@ -41,30 +41,17 @@ class Plugin extends PluginBase
     {
         return [
             'filters' => [
-                'resizePermalink' => function ($image, $identifier, $width, $height = null, $options = []) {
-                    $resizer = new Resizer((string) $image);
-
-                    $width = ($width !== null) ? (int) $width : null;
-                    $height = ($height !== null) ? (int) $height : null;
-                    $options = ($options instanceof Arrayable) ? $options->toArray() : (array) $options;
-
-                    return $resizer->resizePermalink($identifier, $width, $height, $options)->permalink_url;
-                },
-                'modifyPermalink' => function ($identifier, $image, $options = []) {
-                    $resizer = new Resizer((string) $image);
-
-                    $width = null;
-                    $height = null;
-                    $options = ($options instanceof Arrayable) ? $options->toArray() : (array) $options;
-
-                    return $resizer->resizePermalink($identifier, $width, $height, $options)->permalink_url;
-                },
                 'resize' => function ($image, $width, $height = null, $options = []) {
                     $resizer = new Resizer((string) $image);
 
                     $width = ($width !== null) ? (int) $width : null;
                     $height = ($height !== null) ? (int) $height : null;
                     $options = ($options instanceof Arrayable) ? $options->toArray() : (array) $options;
+
+                    // If the given configuration has a permalink identifier then resize using it
+                    if (isset($options['permalink']) && strlen($options['permalink'])) {
+                        return $resizer->resizePermalink($options['permalink'], $width, $height, $options)->permalink_url;
+                    }
 
                     return $resizer->resize($width, $height, $options);
                 },
@@ -74,6 +61,11 @@ class Plugin extends PluginBase
                     $width = null;
                     $height = null;
                     $options = ($options instanceof Arrayable) ? $options->toArray() : (array) $options;
+
+                    // If the given configuration has a permalink identifier then resize using it
+                    if (isset($options['permalink']) && strlen($options['permalink'])) {
+                        return $resizer->resizePermalink($options['permalink'], $width, $height, $options)->permalink_url;
+                    }
 
                     return $resizer->resize($width, $height, $options);
                 },

--- a/classes/Resizer.php
+++ b/classes/Resizer.php
@@ -489,6 +489,8 @@ class Resizer
      */
     public function resizePermalink(string $identifier, int $width = null, int $height = null, array $options = []): ImagePermalink
     {
+        $identifier = trim($identifier, '/');
+
         $width = ($width > 0) ? $width : null;
         $height = ($height > 0) ? $height : null;
 

--- a/commands/ImageResizeResetPermalinks.php
+++ b/commands/ImageResizeResetPermalinks.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ABWebDevelopers\ImageResize\Commands;
+
+use ABWebDevelopers\ImageResize\Classes\Resizer;
+use ABWebDevelopers\ImageResize\Models\ImagePermalink;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class ImageResizeResetPermalinks extends Command
+{
+    protected $name = 'imageresize:reset-permalinks';
+
+    protected $description = 'Delete all permalink configurations in case of needing to regenerate all images using new modifications. If all identifiers are the same, this should have no major affect on the website.';
+
+    public function handle()
+    {
+        $deleted = ImagePermalink::count();
+
+        // Delete all permalinks
+        ImagePermalink::query()->delete();
+
+        $this->info('Successfully deleted ' . $deleted . ' ' . Str::plural('permalinks', $deleted));
+    }
+}

--- a/commands/ImageResizeResetPermalinks.php
+++ b/commands/ImageResizeResetPermalinks.php
@@ -2,7 +2,6 @@
 
 namespace ABWebDevelopers\ImageResize\Commands;
 
-use ABWebDevelopers\ImageResize\Classes\Resizer;
 use ABWebDevelopers\ImageResize\Models\ImagePermalink;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;

--- a/commands/ImageResizeResetPermalinks.php
+++ b/commands/ImageResizeResetPermalinks.php
@@ -2,6 +2,7 @@
 
 namespace ABWebDevelopers\ImageResize\Commands;
 
+use ABWebDevelopers\ImageResize\Classes\Resizer;
 use ABWebDevelopers\ImageResize\Models\ImagePermalink;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;

--- a/models/ImagePermalink.php
+++ b/models/ImagePermalink.php
@@ -26,6 +26,16 @@ class ImagePermalink extends Model
     ];
 
     /**
+     * When casting this object to string, retrieve the Permalink URL
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->permalink_url;
+    }
+
+    /**
      * Scope all results by those matching the identifier (should always be only one)
      *
      * @param Builder $query

--- a/models/ImagePermalink.php
+++ b/models/ImagePermalink.php
@@ -86,8 +86,6 @@ class ImagePermalink extends Model
 
             $path = $resizer->getRelativePath();
 
-            list($mime, $format) = $resizer->detectFormat(true);
-
             $this->path = $path;
             $this->resized_at = now();
             $this->save();

--- a/models/ImagePermalink.php
+++ b/models/ImagePermalink.php
@@ -157,6 +157,7 @@ class ImagePermalink extends Model
         $this->resize(); // if not resized
 
         header('Content-Type: ' . $this->mime);
+        header('Content-Length: ' . filesize($this->absolute_path));
         echo file_get_contents($this->absolute_path);
         exit();
     }

--- a/models/ImagePermalink.php
+++ b/models/ImagePermalink.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace ABWebDevelopers\ImageResize\Models;
+
+use ABWebDevelopers\ImageResize\Classes\Resizer;
+use Illuminate\Database\Eloquent\Builder;
+use Model;
+
+class ImagePermalink extends Model
+{
+    public $table = 'abweb_imageresize_permalinks';
+
+    /**
+     * Define cast types for each modifier type
+     *
+     * @var array
+     */
+    protected $castModifiers = [
+        'identifier' => 'string',
+        'image' => 'string',
+        'path' => 'string',
+    ];
+
+    public $jsonable = [
+        'options',
+    ];
+
+    /**
+     * Scope all results by those matching the identifier (should always be only one)
+     *
+     * @param Builder $query
+     * @param string $identifier
+     * @return void
+     */
+    public function scopeByIdentifier(Builder $query, string $identifier): void
+    {
+        $query->where('identifier', $identifier);
+    }
+
+    /**
+     * Get the Image Permalink with this identifier if it exists
+     *
+     * @param string $identifier
+     * @return ImagePermalink|null
+     */
+    public static function withIdentifer(string $identifier): ?ImagePermalink
+    {
+        return static::byIdentifier($identifier)->first();
+    }
+
+    /**
+     * Does the resized version of this image exist?
+     *
+     * @return boolean
+     */
+    public function resizeExists(): bool
+    {
+        return !empty($this->path) && file_exists($this->absolute_path);
+    }
+
+    /**
+     * Generate a short life hash for this file.
+     * This will be where the image is stored in the storage path
+     *
+     * @return string
+     */
+    public function generateShortLifeHash(): string
+    {
+        return hash('sha256', $this->identifier . ':permalink:' . json_encode($this->options));
+    }
+
+    /**
+     * Resize the image, if not already resized
+     *
+     * @return void
+     */
+    public function resize()
+    {
+        if ($this->resizeExists() === false) {
+            $config = $this->options ?? [];
+
+            $resizer = Resizer::using($this->image)
+                ->setHash($hash = $this->generateShortLifeHash())
+                ->setOptions($config)
+                ->doResize();
+
+            $path = $resizer->getRelativePath();
+
+            list($mime, $format) = $resizer->detectFormat(true);
+
+            $this->path = $path;
+            $this->resized_at = now();
+            $this->save();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the absolute path to the resized image
+     *
+     * @return string
+     */
+    public function getAbsolutePathAttribute(): string
+    {
+        return base_path($this->path);
+    }
+
+    /**
+     * Get the permalink URL for this image
+     *
+     * @return string
+     */
+    public function getPermalinkUrlAttribute(): string
+    {
+        return url('/imageresizestatic/' . $this->identifier . '.' . $this->extension);
+    }
+
+    /**
+     * Render this image to screen, now.
+     *
+     * @return void
+     */
+    public function render()
+    {
+        $this->resize(); // if not resized
+
+        header('Content-Type: ' . $this->mime);
+        echo file_get_contents($this->absolute_path);
+        exit();
+    }
+
+    public static function fromResizer(string $identifier, Resizer $resizer): ImagePermalink
+    {
+        $that = static::withIdentifer($identifier);
+
+        if ($that === null) {
+            $that = new static();
+
+            list($mime, $format) = $resizer->detectFormat(true);
+
+            $that->identifier = $identifier;
+            $that->image = $resizer->getImagePath();
+            $that->mime_type = 'image/' . $mime;
+            $that->extension = $format;
+            $that->options = $resizer->getOptions();
+
+            $that->save();
+        }
+
+        return $that;
+    }
+}

--- a/routes.php
+++ b/routes.php
@@ -1,6 +1,7 @@
 <?php
 
 use ABWebDevelopers\ImageResize\Classes\Resizer;
+use ABWebDevelopers\ImageResize\Models\ImagePermalink;
 use Illuminate\Support\Facades\Cache;
 
 /**
@@ -24,3 +25,12 @@ Route::get('imageresize/{hash}.{ext}', function (string $hash, string $ext) {
         ->doResize()
         ->render();
 });
+
+/**
+ * Publicly accessible URL for permalink image using an identifier/ext.
+ */
+Route::get('imageresizestatic/{identifier}.{ext}', function (string $identifier, string $ext) {
+    $perma = ImagePermalink::withIdentifer($identifier);
+
+    return $perma->render();
+})->where('identifier', '(.+?)');

--- a/routes.php
+++ b/routes.php
@@ -32,5 +32,9 @@ Route::get('imageresize/{hash}.{ext}', function (string $hash, string $ext) {
 Route::get('imageresizestatic/{identifier}.{ext}', function (string $identifier, string $ext) {
     $perma = ImagePermalink::withIdentifer($identifier);
 
+    if ($perma === null) {
+        $perma = ImagePermalink::defaultNotFound();
+    }
+
     return $perma->render();
 })->where('identifier', '(.+?)');

--- a/traits/HasPermalinkIdentifiers.php
+++ b/traits/HasPermalinkIdentifiers.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ABWebDevelopers\ImageResize\Traits;
+
+trait HasPermalinkIdentifiers
+{
+    /**
+     * Get the identifier for the permalink
+     *
+     * @param string $key
+     * @return string
+     */
+    public function getPermalinkIdentifier(string $key = null): string
+    {
+        if ($key !== null) {
+            $key .= '/';
+        }
+
+        return $key . strtolower(basename(str_replace('\\', '/', static::class))) . '/' . $this->slug;
+    }
+}

--- a/updates/create_permalinks_table.php
+++ b/updates/create_permalinks_table.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ABWebDevelopers\ImageResize\Updates;
+
+use October\Rain\Database\Updates\Migration;
+use Schema;
+
+class CreatePermalinksTable extends Migration
+{
+    public function up()
+    {
+        if (Schema::hasTable('abweb_imageresize_permalinks') === false) {
+            Schema::create('abweb_imageresize_permalinks', function ($table) {
+                $table->increments('id');
+
+                $table->text('identifier');
+                $table->text('image');
+                $table->string('mime_type');
+                $table->string('extension');
+                $table->text('options')->default('{}');
+                $table->text('path')->nullable()->default(null);
+                $table->dateTime('resized_at')->nullable()->default(null);
+
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down()
+    {
+        if (Schema::hasTable('abweb_imageresize_permalinks') === true) {
+            Schema::dropTable('abweb_imageresize_permalinks');
+        }
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -43,3 +43,6 @@
   - Added twig filter to parse and resize/modify images (via regex) using twig filter(s)
 2.1.9:
   - Improvement to the detection of the original image's mime type (uses less system resources)
+2.2.0:
+  - Added optional permalinks for images to ensure image URLs always yield the same image after cache flushes
+  - create_permalinks_table.php


### PR DESCRIPTION
An issue we've faced - and I'm sure others have too - is that an image can be resized in emails and sent to customers, but then a few days later when the cache is flushed (especially after changing image resize settings around) a new set of hashes are generated for the [otherwise]-exact same image which yield a new URL and a broken old URL.

The solution to that is to implement permalinks to this plugin, so that no matter what configuration is used the same image will always be returned. Because of this, the need for an "identifier" was spawned, which funnily enough doubles as the solution for yet another issue that I've seen once or two in the past: SEO/nameable images.

In this PR I have added a new `/imageresizestatic/{identifier}.{ext}` route which looks for a permalink based on the identifier (which can be delicately named for SEO purposes) and resizes the image OTF (when needed) or simply serves the cached copy via PHP. Also I have added 2x new twig filters similar to `resize` and `modify` which do the exact same, except the first argument to the filters are now the identifier(s). This could be anything you need it to be (although keep it unique): `logo`, `brands/partner-logo`, `social-media-logo-reddit`, etc. The permalinks are persisted to the database, and can be deleted when needed via a new console command, however since they're all permalinks all this is really going to do is force the plugin to re-render the images with any new configurations without breaking old links